### PR TITLE
Remove deprecated use of `ModelFilter`

### DIFF
--- a/scripts/code_model_info.py
+++ b/scripts/code_model_info.py
@@ -1,5 +1,5 @@
 from transformers import AutoConfig, AutoModel
-from huggingface_hub import HfApi, ModelFilter
+from huggingface_hub import HfApi
 
 def get_model_information(model):
 
@@ -28,16 +28,8 @@ def get_model_information(model):
 
 
 def retrieve_all_huggingface_models(filtering_language):
-    
-    api = HfApi()
-    model_list = api.list_models(
-        filter=ModelFilter(
-            language=filtering_language
-        )
-    )
-    model_list = list(model_list)
-    
-    return model_list
+    return list(HfApi().list_models(language=filtering_language))
+
 
 
 def group_models_by_year(model_list):

--- a/scripts/target_code_model_info.py
+++ b/scripts/target_code_model_info.py
@@ -1,5 +1,5 @@
 from transformers import AutoConfig, AutoModel
-from huggingface_hub import HfApi, ModelFilter
+from huggingface_hub import HfApi
 
 def get_model_information(model):
 
@@ -28,16 +28,7 @@ def get_model_information(model):
 
 
 def retrieve_all_huggingface_models(filtering_language):
-    
-    api = HfApi()
-    model_list = api.list_models(
-        filter=ModelFilter(
-            language=filtering_language
-        )
-    )
-    model_list = list(model_list)
-    
-    return model_list
+    return list(HfApi().list_models(language=filtering_language))
 
 
 def group_models_by_year(model_list):


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.